### PR TITLE
set render interval to decimation to fix the simulation speed issue

### DIFF
--- a/custom_rl_env.py
+++ b/custom_rl_env.py
@@ -274,6 +274,7 @@ class LocomotionVelocityRoughEnvCfg(RLTaskEnvCfg):
         """Post initialization."""
         # general settings
         self.decimation = 4
+        self.sim.render_interval = self.decimation
         self.episode_length_s = 20.0
         # simulation settings
         self.sim.dt = 0.005


### PR DESCRIPTION
According to a comment on https://github.com/abizovnuralem/go2_omniverse/issues/19#issuecomment-2320391062, a speed issue occurs when upgrading Isaac Sim from 2023.1.x to Isaac 4.0+.

## Issue: 
The problem has been traced to the handling of ```self.decimation``` and ```self.sim.render_interval``` within IsaacLab/Orbit’s RLTaskEnvCfg. In Isaac Sim 2023, the default setting is:
```
self.sim.render_interval = self.decimation
```
This configuration renders once per "step" rather than every substep. However, starting with IsaacLab 4.0+, the value is instead set to 1:
```
self.sim.render_interval = 1
```
This forces the simulation to render every substep, which is unnecessary and results in a significant slowdown.



## Solution:
To resolve the issue, explicitly set self.sim.render_interval to self.decimation when initializing the RLTaskEnvCfg. This adjustment has been confirmed to work in the [isaac-go2-ros2 repository](https://github.com/Zhefan-Xu/isaac-go2-ros2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved simulation configuration ensures the rendering timing now aligns more closely with performance settings, delivering a smoother and more consistent visual experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->